### PR TITLE
Fix session URL links

### DIFF
--- a/src/workflow-links.ts
+++ b/src/workflow-links.ts
@@ -9,6 +9,7 @@ import {
   SessionResult,
   PageOfTableSummary,
   TableSummary,
+  RunWorkflowResponse,
 } from "./client";
 import { addSchemaMetadataByType } from "./schema";
 import {
@@ -18,6 +19,7 @@ import {
   PageOfSessionSummarySchema,
   SessionResultSchema,
   PageOfTableSummarySchema,
+  RunWorkflowResponseSchema,
 } from "./client/schemas.gen";
 import { ToolCall } from "./links";
 import { relinkTableSummary } from "./table-links";
@@ -183,5 +185,35 @@ export function relinkWorkflowVersion(
       "@links": links,
     },
     WorkflowVersionDetailsSchema,
+  );
+}
+
+export function transformRunWorkflowResponse(
+  response: RunWorkflowResponse,
+  workflowId: string,
+): Record<string, any> {
+  // Generate the correct app URL based on session mode
+  const isTestMode = response.sessionMode === "TEST";
+  const appSessionUrl = `https://app.workflow86.com/project/logs/progress_view/${workflowId}/${response.sessionId}?test=${isTestMode}`;
+  
+  const links: Record<string, ToolCall> = {};
+  
+  // Add link to get session details
+  if (response.sessionId) {
+    links["session-details"] = {
+      name: "get-session",
+      arguments: {
+        sessionId: response.sessionId,
+      },
+    };
+  }
+  
+  return addSchemaMetadataByType(
+    {
+      ...response,
+      sessionUrl: appSessionUrl,
+      "@links": links,
+    },
+    RunWorkflowResponseSchema,
   );
 }

--- a/src/workflow-tools.ts
+++ b/src/workflow-tools.ts
@@ -19,6 +19,7 @@ import {
   relinkWorkflowHistoryPage,
   relinkWorkflowPage,
   relinkWorkflowVersion,
+  transformRunWorkflowResponse,
 } from "./workflow-links.js";
 import { addSchemaMetadataByType, createSchemaDescriber } from "./schema";
 import {
@@ -178,7 +179,7 @@ export function registerWorkflowTools(server: McpServer) {
         });
 
         return jsonResponse(
-          addSchemaMetadataByType(response.data, "RunWorkflowResponse"),
+          transformRunWorkflowResponse(response.data, workflowId),
         );
       } catch (error) {
         return handleError(error);
@@ -218,7 +219,7 @@ export function registerWorkflowTools(server: McpServer) {
         });
 
         return jsonResponse(
-          addSchemaMetadataByType(response.data, "RunWorkflowResponse"),
+          transformRunWorkflowResponse(response.data, workflowId),
         );
       } catch (error) {
         return handleError(error);


### PR DESCRIPTION
## 🔧 Fix: Correct Session URL Generation for Workflow Runs

### Problem
The MCP server was returning incorrect session URLs when workflows were executed. The AI was showing REST API endpoint URLs instead of the user-friendly app URLs that users can actually click to view their workflow sessions.

**Before (Incorrect):**
```
https://rest.workflow86.com/v1/session/{sessionId}
```

**After (Correct):**
```
https://app.workflow86.com/project/logs/progress_view/{workflowId}/{sessionId}?test={true|false}
```

### Solution
Added a new `transformRunWorkflowResponse()` function that:
- Generates the correct app URL format for session viewing
- Properly includes the workflow ID in the URL path
- Adds the appropriate `test` query parameter based on session mode (`TEST` → `?test=true`, `PROD` → `?test=false`)
- Preserves all other response data and adds helpful navigation links

### Changes Made
1. **`src/workflow-links.ts`**: 
   - Added `transformRunWorkflowResponse()` function to generate correct app URLs
   - Imported necessary types (`RunWorkflowResponse`, `RunWorkflowResponseSchema`)

2. **`src/workflow-tools.ts`**: 
   - Updated `run-workflow` tool to use the transformation function
   - Updated `rerun-workflow` tool to use the transformation function
   - Both tools now return properly formatted session URLs

### Testing
✅ All existing unit tests pass
✅ Build compiles successfully
✅ Manual testing confirms correct URL generation for both TEST and PROD modes

### Example Output
When running a workflow, users will now see:

**Test Mode:**
```
Session URL: https://app.workflow86.com/project/logs/progress_view/1bfe37a6-8945-4a46-acc5-7ef1b944153e/aece9361-c6f1-4784-836a-adafb381015c?test=true
```

**Production Mode:**
```
Session URL: https://app.workflow86.com/project/logs/progress_view/1bfe37a6-8945-4a46-acc5-7ef1b944153e/8c3b8f32-7a91-493b-9a39-cca5e3cca495?test=false
```

These URLs are clickable and take users directly to the workflow session progress view in the app.

### Impact
- **User Experience**: Users get clickable URLs that work immediately
- **Developer Experience**: AI assistants using this MCP server will provide correct, actionable session links
- **Backward Compatibility**: All existing functionality preserved; only the URL format in responses is improved

---
Fixes the session URL generation issue where REST API endpoints were shown instead of app URLs.
